### PR TITLE
Two small bug-fixes

### DIFF
--- a/map80ram.c
+++ b/map80ram.c
@@ -124,6 +124,17 @@ void map80RamInitialise(){
         printf("size of NascomMonVWram ram %ld \n", sizeof NascomMonVWram);
     }
     memset(&NascomMonVWram, 0x76,sizeof NascomMonVWram );  /* Fill with the halt instruction */
+    // when nasbug T4 or nas-sys monitors start up, they restore the breakpoint byte at the
+    // breakpoint address. The effect is to write 76H to address 7676H. Usually this is not
+    // a problem. However, for the case where a command-line argument is used to load a .nas
+    // file, and that file loads 7676H, the monitor start up will corrupt the data at that
+    // address. To avoid this nastiness, set brkadr to 0 (which is read-only and so will
+    // not be affected by the write of 76H.
+    NascomMonVWram[0x0c15]=0; // nasbug T4
+    NascomMonVWram[0x0c16]=0;
+    NascomMonVWram[0x0c23]=0; // nas-sys
+    NascomMonVWram[0x0c24]=0;
+
     if (rampagedebug){
         printf("size of virtual ram %ld \n", sizeof virutalram);
     }

--- a/nasutils.c
+++ b/nasutils.c
@@ -12,11 +12,59 @@
 #include "map80nascom.h"
 #include "utilities.h"
 
+// Expect a line of text from a NAS file. It should start with 1, 4-digit hex address and either
+// 9, 2-digit hex data bytes or fewer. In the case of 9 the 9th is a checksum byte. If the
+// checksum is present, check it and report an error if it's bad.
+// return 0 if address and at least 1 data byte and no checksum error OR if valid end
+// otherwise return 1.
+// bytes[] holds 8 elements; count is the number of valid bytes
+int parseNASline(int line, const char *buf, int *address, int *count, unsigned int *bytes)
+{
+    unsigned int checksum;
+    *count = sscanf(buf, "%4x %2x %2x %2x %2x %2x %2x %2x %2x %2x", address,
+                    &bytes[0], &bytes[1], &bytes[2], &bytes[3],
+                    &bytes[4], &bytes[5], &bytes[6], &bytes[7],
+                    &checksum);
+
+    if ((buf[0] == '.') || (buf[0] == '\r')) {
+        // terminator or blank line - OK
+        *count = 0;
+        return 0;
+    }
+
+    if (*count < 2) {
+        // address only or not even that - bad
+        *count = 0;
+        return 1;
+    }
+
+    if (*count == 10) {
+        // address, 8 data and checksum
+        unsigned int calcsum;
+        *count = 8;
+        calcsum = (*address >> 8) + (*address & 0xff);
+        for (int i=0; i<8; i++) {
+            calcsum += bytes[i];
+        }
+        if ((calcsum & 0xff) == checksum) {
+            return 0;
+        }
+        else {
+            if (verbose) printf("\tError on line %d - calculated checksum 0x%2X does not match 0x%2X\n",line, calcsum & 0xff, checksum);
+            return 1;
+        }
+    }
+
+    // address, 1-8 data
+    *count = *count - 1;
+    return 0;
+}
+
 
 // load a Nascom NAS format file into memory.
 // It can be any filename.
 // The extention is normally .nas, but can be .nal
-// A file with a .rom extention will be loaded into it's own ROM space.
+// A file with a .rom extention will be loaded into its own ROM space.
 //   That makes it Read only and locked in the memory space - like the EPROMS on the Nascom 2 board.
 //   The limits are it must start on a 2k boundary in memory and must not be more than 8k long.
 // 
@@ -25,7 +73,6 @@
 // returns 0 if all okay anything else is a failure
 // will load into ram space but if .nal file it will create a rom space 
 // and copy it from ram space to there.
-
 int loadNASformat(const char *filetoload)
 {
     int retval=0;
@@ -35,9 +82,8 @@ int loadNASformat(const char *filetoload)
     int count1=0;
     int count2=0;
     int namelen=0;
-    
+
     namelen=strlen(filetoload);
-    
     if (verbose) printf("Loading %s\n", filetoload);
 
     // find the . in the file name
@@ -48,7 +94,7 @@ int loadNASformat(const char *filetoload)
     }
     
     count1++; // allow for the .
-    // check if we have any extention 
+    // check if we have any extension 
     if (count1<1){
         if (verbose) printf("\tWarning - No extention on file %s\n", filetoload);
         count1=namelen;
@@ -64,8 +110,7 @@ int loadNASformat(const char *filetoload)
         fileext[count2]=mytolower(filetoload[count1]);
     }
     fileext[count2]=0; // mark end
-    if (verbose) printf("\tfile ext %s\n",fileext);
-    
+
     // split it out to make it easier to read the code :)
     retval=loadNASformatinternal(filetoload,&firstaddress,&lastaddress );
     
@@ -84,13 +129,13 @@ int loadNASformat(const char *filetoload)
             // also if > 0x1000
             // if not could upset the nascom stuff if it tries to be rom
             if (firstaddress < 0x1000){
-                if (verbose) printf("\tcannot activate as rom as below address 0x1000\n");
+                if (verbose) printf("\tcannot activate as ROM as below address 0x1000\n");
             }
             else if ((firstaddress % 2048) > 0 ) {
-                if (verbose) printf("\tcannot activate as rom as not starting on a 2k boundary\n");
+                if (verbose) printf("\tcannot activate as ROM as not starting on a 2k boundary\n");
             }
             else if (memoryused > (8*1024)  ) {
-                if (verbose) printf("\tcannot activate as rom as larger than 8k\n");
+                if (verbose) printf("\tcannot activate as ROM as larger than 8k\n");
             }
             else {
                 // the memory must be in 2k chunks
@@ -120,10 +165,9 @@ int loadNASformat(const char *filetoload)
                     // which entry do we need to use
                     int rampageentry = ((firstaddress)>>RAMPAGESHIFTBITS) & RAMPAGETABLESIZEMASK;
                     // printf("ram page table entry %2.2X\n",rampageentry);
-                    
+
                     for (int memoryusedcopy=memoryused ;memoryusedcopy>0 ;memoryusedcopy-=(RAMPAGESIZE*1024), rampageentry++ )  {
                         if (rampageentry<RAMPAGETABLESIZE){
-                            
                             rampagetable[rampageentry]=newmemory;
                             ramromtable[rampageentry]=1;    // say it is rom
                             ramlocktable[rampageentry]=1;   // and active nas ram disable 
@@ -137,37 +181,31 @@ int loadNASformat(const char *filetoload)
                         newmemory+=(RAMPAGESIZE*1024);
                     }
                     if (verbose) printf("\tLoaded into ROM at address 0x%4.4X for 0x%2.2X bytes\n",firstaddress,memoryused);
-                    
                 }
-                
             }
-        }        
-        
+        }
     }
     else {
         if (verbose) printf("\tWarning - problem loading %s\n",filetoload);
     }
-    
     return retval;
 }
 
-// this processes the file an returns first and last address used 
-// technically the lowest and highest 
-
+// process the file and returns first (lowest) and last (highest) address used
 int loadNASformatinternal(const char *filetoload, int *firstaddressused, int *lastaddressused )
 {
     int address;
-    unsigned int bytecsum;
-    unsigned int bytes[8];   // 0 to 7 bytes to receive data
-    int count = 0;
-    int ch;
-    int numberRead;
-    unsigned int checksum;
-    int lineNumber=0;
+    int validbytes;
+    unsigned int bytes[8];
+    int lineNumber = 0;
 
-    int retval=0;   // defaults to all okay
+    int retval = 0;   // defaults to all okay
+    int totalbytes = 0;
+
     int firstaddress = 100000;
     int lastaddress = -1;
+
+    char line[80]; // one line from the .nas file
 
     FILE *f = fopen(filetoload, "r");
 
@@ -176,64 +214,22 @@ int loadNASformatinternal(const char *filetoload, int *firstaddressused, int *la
         return 1;
     }
 
-
-    // loop through until end of file
-    for (; !feof(f) ;) {
-        numberRead = fscanf(f, "%x %x %x %x %x %x %x %x %x %x",
-                   &address, &bytes[0], &bytes[1], &bytes[2], &bytes[3], &bytes[4], &bytes[5], &bytes[6], &bytes[7], &bytecsum );
+    // process file line by line
+    while (fgets(line, sizeof line, f) != NULL) {
         lineNumber++;
-        if (numberRead == 10){
-            // 10 entries - address and 8 bytes and checksum byte
-            // this bit of code checks the checksum 
-            // first add in address
-            numberRead=9; // fix for next bit
-            // calculate checksum
-            checksum = (((address & 0xFF) + ((address & 0xFF00)>>8)) & 0xFF);
-            //printf("checksum after address %4.4X is %2.2X \n",address,checksum);
-            for (int byteNumber=0;byteNumber<8;byteNumber++){
-                checksum = (( checksum + (bytes[byteNumber] & 0xFF)) & 0xFF) ;
-            }
-            if (checksum != bytecsum){
-                if (verbose) printf("\t%s - checksum failure on line %d, calculated checksum"
-                               " 0x%1X does not match one from file 0x%1X \n",
-                               filetoload, lineNumber,checksum,bytecsum);
-                retval=1; // signify error - but process rest of file
-            }
-            //printf("checksum %4.4X from file %2.2X \n",checksum,bytecsum);
+        retval |= parseNASline(lineNumber, line, &address, &validbytes, bytes);
 
+        if (firstaddress > address) {
+            firstaddress=address;
         }
-        // now load the bytes into memory 
-        // TODO - what to do if not actually 8 bytes
-        // at present it ignores them
-        if (numberRead == 9){
-            if (firstaddress > address ){
-                firstaddress=address;
+
+        for (int i=0; i<validbytes; i++) {
+            RAM(address)=bytes[i];
+            if (lastaddress<address){
+                lastaddress=address;
             }
-            // 9 entries - address and 8 bytes
-            for (int byteNumber=0;byteNumber<8;byteNumber++){
-                RAM(address)=bytes[byteNumber];
-                if (lastaddress<address){
-                    lastaddress=address;
-                }
-                address++;
-                count ++;
-            }
-            
-        }
-/*
-        else {
-            if (numberRead == )
-            printf("%s line %d unable to identify 8 bytes of data to load\n",filetoload,lineNumber);
-            retval=1; // signify error - but process rest of file
-        }
-*/
-        // skip to end of line in the file
-        do
-            ch = fgetc(f);
-        while (ch != -1 && ch != '\n');
-        // end of file exit
-        if (ch == -1){
-            break;
+            address++;
+            totalbytes++;
         }
     }
 
@@ -244,35 +240,32 @@ int loadNASformatinternal(const char *filetoload, int *firstaddressused, int *la
     }
     if (verbose){
         if (retval){
-            printf("\tError: Problems during load\n");
+            printf("\tError(s) during load. Loaded %d bytes into memory (0x%04X - 0x%04X)\n", totalbytes, firstaddress, lastaddress);
         } else {
-            printf("\tSuccessfully loaded %d bytes\n", count);
+            printf("\tSuccessfully loaded %d bytes into memory (0x%04X - 0x%04X)\n", totalbytes, firstaddress, lastaddress);
         }
     }
-    //printf("returning %d \n",retval);
-    // return the addresses used 
+
+    // the address range used
     *firstaddressused = firstaddress;
     *lastaddressused = lastaddress;
     return retval;
 }
 
-// loads a nas file into a specific part of memory 
-// used to load the nassys3 and map80vfc rom file
-
+// load a nas file into a specific part of memory -- used to load the nassys3 and map80vfc rom file
 int loadNASformatspecial(const char *filetoload, unsigned char *memory, int memorySize)
 {
     int address;
-    unsigned int bytecsum;
-    unsigned int bytes[8];   // 0 to 7 bytes to receive data
-    int count = 0;
-    int ch;
-    int numberRead;
-    unsigned int checksum;
-    int lineNumber=0;
+    int validbytes;
+    unsigned int bytes[8];
+    int lineNumber = 0;
 
-    int retval=0;   // defaults to all okay
+    int retval = 0;   // defaults to all okay
+    int totalbytes = 0;
 
     if (verbose) printf("Loading %s\n", filetoload);
+
+    char line[80]; // one line from the .nas file
 
     FILE *f = fopen(filetoload, "r");
 
@@ -281,85 +274,40 @@ int loadNASformatspecial(const char *filetoload, unsigned char *memory, int memo
         return 1;
     }
 
-    // loop through until end of file
-    for (; !feof(f) ;) {
-        numberRead = fscanf(f, "%x %x %x %x %x %x %x %x %x %x",
-                   &address, &bytes[0], &bytes[1], &bytes[2], &bytes[3], &bytes[4], &bytes[5], &bytes[6], &bytes[7], &bytecsum );
+    // process file line by line
+    while (fgets(line, sizeof line, f) != NULL) {
         lineNumber++;
-        if (numberRead == 10){
-            // 10 entries - address and 8 bytes and checksum byte
-            // this bit of code checks the checksum 
-            // first add in address
-            numberRead=9; // fix for next bit
-            // calculate checksum
-            checksum = (((address & 0xFF) + ((address & 0xFF00)>>8)) & 0xFF);
-            //printf("checksum after address %4.4X is %2.2X \n",address,checksum);
-            for (int byteNumber=0;byteNumber<8;byteNumber++){
-                checksum = (( checksum + (bytes[byteNumber] & 0xFF)) & 0xFF) ;
-            }
-            if (checksum != bytecsum){
-                if (verbose) printf("\t%s - checksum failure on line %d, calculated checksum"
-                               " 0x%1X does not match one from file 0x%1X \n",
-                               filetoload, lineNumber,checksum,bytecsum);
-                retval=1; // signify error - but process rest of file
-            }
-            //printf("checksum %4.4X from file %2.2X \n",checksum,bytecsum);
+        retval |= parseNASline(lineNumber, line, &address, &validbytes, bytes);
 
-        }
-        // now load the bytes into memory 
-        // TODO - what to do if not actually 8 bytes
-        // at present it ignores them
-        if (numberRead == 9){
-            // 9 entries - address and 8 bytes
-            for (int byteNumber=0;byteNumber<8;byteNumber++){
-                if (address < memorySize){
-                    memory[address] = bytes[byteNumber];
-                    address++;
-                    count ++;
-                }
-                else {
-                    if (verbose) printf("\t%s Address 0x%1X on line %d passed end of memory size 0x%1X \n",
-                                   filetoload,address,lineNumber,memorySize);
-                    retval=1; // signify error - but process rest of file
-                    break;
-                }
+        for (int i=0; i<validbytes; i++){
+            if (address < memorySize){
+                memory[address] = bytes[i];
+                address++;
+                totalbytes++;
             }
-        }
-/*
-        else {
-            if (numberRead == )
-            printf("%s line %d unable to identify 8 bytes of data to load\n",filetoload,lineNumber);
-            retval=1; // signify error - but process rest of file
-        }
-*/
-        // skip to end of line in the file
-        do
-            ch = fgetc(f);
-        while (ch != -1 && ch != '\n');
-        // end of file exit
-        if (ch == -1){
-            break;
+            else {
+                if (verbose) printf("\t%s Address 0x%1X on line %d passed end of memory size 0x%1X \n",
+                                    filetoload,address,lineNumber,memorySize);
+                retval=1; // signify error - but process rest of file
+                break;
+            }
         }
     }
 
     fclose(f);
     if (verbose){
-        if (count<1){
+        if (totalbytes<1){
             printf("\tWarning: No data loaded\n");
         }
         else {
             if (retval){
-                printf("\tError: Problems during load\n");
+                printf("\tError(s) during load. Loaded %d bytes into its own memory\n", totalbytes);
             } else {
-                printf("\tSuccessfully loaded %d bytes into it's own memory\n", count);
+                printf("\tSuccessfully loaded %d bytes into its own memory\n", totalbytes);
             }
         }
     }
-
     return retval;
-
 }
 
-
-
-// end of file
+// end of nasutils.c


### PR DESCRIPTION
1/ when you load multiple .NAS files the monitor startup can corrupt a byte if the .NAS files straddle address 0x7676. The problem is caused by the breakpoint restore code in the monitor. Cannot be a problem on a real system. Fix is to make sure that 4 of the workspace locations are initialised to 0 instead of 0x76 (2 locations for NASBUG, 2 locations for NAS-SYS)

2/ .NAS file loader only worked for files that included 8 bytes of data + checksum. Refactored the code and added support for
between 1 and 9 bytes. If 9 are present the last one is treated as a checksum and checked as before.

I'm finding your emulator really useful. I love the serial file save/load and the ease with which I can load up different monitor ROMS. I added support for the NASCOM4 SDcard and used your emulator to debug my CP/M port to that machine.